### PR TITLE
Update types / createStore

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,14 +1,12 @@
 import * as React from "react";
 import { Provider } from "react-redux";
-import { configureStore, ConfigureStoreOptions } from "@reduxjs/toolkit";
+import { ConfigureStoreOptions } from "@reduxjs/toolkit";
+import { createStore } from "../src/app/store";
 
 type MakeOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 export function withStoreProvider<S = any>(options: MakeOptional<ConfigureStoreOptions<S, any, any>, "reducer">) {
-  const store = configureStore({
-    reducer: (x: any) => x,
-    ...options,
-  });
+  const store = createStore(options);
   return (storyFn: () => JSX.Element) => {
     return <Provider store={store}>{storyFn()}</Provider>;
   };

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -7,7 +7,7 @@ import {
 import counterReducer from "../features/counter/counterSlice";
 
 // Export a store creator helper for usage by the stories
-export const createStore = (options?: ConfigureStoreOptions) =>
+export const createStore = (options?: Partial<ConfigureStoreOptions>) =>
   configureStore({ reducer: { counter: counterReducer }, ...options });
 
 export const store = createStore();


### PR DESCRIPTION
Did some experimenting with `addDecorator`, and I don't think there's any value in going any further than this. I think for most every use case, this would be about the extent of what's needed.  We could allow for parameters to be passed in and some type of merging with whatever `context`, but it seems 100% unnecessary. I also think having people getting really used to the `configureStore` options is a good idea :)

I'm going to work on a draft for the Redux docs, so we can just touch base about this tomorrow as its a non-priority 🎉 